### PR TITLE
Add AUR listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ wget "https://github.com/sharkdp/dup/releases/download/v0.2.0/dup_0.2.0_amd64.de
 sudo dpkg -i dup_0.2.0_amd64.deb
 ```
 
+### On Arch-based systems
+
+Download from [the AUR](https://aur.archlinux.org/packages/du-dup-bin/) and install using `makepkg` or an AUR-helper
+
 ### On other distrubutions
 
 Check out the [release page](https://github.com/sharkdp/dup/releases) for binary builds.


### PR DESCRIPTION
Created an Arch Linux package for personal use. Decided to upload to the AUR. You can add the link to the description for other to see and use, too :)

P.S. I named it du-dup-bin for multiple reasons. Firstly, there already is a dup package, so I guessed it wouldn't be a problem to name it du-dup like in the case with cargo. And secondly, -bin because it is a prebuilt package, a package that compiles from source  wouldn't have such a suffix.