### PR TITLE
Add windows ci builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: rust
 cache: cargo
 matrix:
+  allow_failures:
+    - os: windows
   include:
     # Stable channel.
     - os: linux
@@ -12,14 +14,13 @@ matrix:
     - os: osx
       rust: stable
       env: TARGET=x86_64-apple-darwin
+    - os: windows
+      rust: stable
+      env: TARGET=x86_64-pc-windows-msvc
     # Minimum Rust supported channel.
     - os: linux
       rust: 1.29.0
       env: TARGET=x86_64-unknown-linux-gnu
-    - os: windows
-      rust: stable
-      env: TARGET=x86_64-pc-windows-msvc
-
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ matrix:
     - os: linux
       rust: 1.29.0
       env: TARGET=x86_64-unknown-linux-gnu
+    - os: windows
+      rust: stable
+      env: TARGET=x86_64-pc-windows-msvc
 
 
 addons:


### PR DESCRIPTION
This PR enables windows builds. Currently they're failing because diskus does not work on windows so failures on CI are allowed for windows. But once support is added for windows we can require the windows tests to pass