### PR TITLE
Fixed grammar in error messages

### DIFF
--- a/src/walk.rs
+++ b/src/walk.rs
@@ -94,7 +94,7 @@ impl<'a> Walk<'a> {
                     }
                     Message::NoMetadataForPath(path) => {
                         eprintln!(
-                            "diskus: could not find metadata for path '{}'",
+                            "diskus: could not retrieve metadata for path '{}'",
                             path.to_string_lossy()
                         );
                     }

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -94,13 +94,13 @@ impl<'a> Walk<'a> {
                     }
                     Message::NoMetadataForPath(path) => {
                         eprintln!(
-                            "diskus: could not metadata for path '{}'",
+                            "diskus: could not find metadata for path '{}'",
                             path.to_string_lossy()
                         );
                     }
                     Message::CouldNotReadDir(path) => {
                         eprintln!(
-                            "diskus: could not contents of directory '{}'",
+                            "diskus: could not read contents of directory '{}'",
                             path.to_string_lossy()
                         );
                     }


### PR DESCRIPTION
Fixed a minor grammar error.

When `diskus` can't read a directory it prints out
`diskus: could not contents of directory './my/folder`

It will now print the grammatically correct
`diskus: could not read contents of directory './my/folder`