### PR TITLE
Add installation instructions for Void Linux and Haiku

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,19 @@ sudo dpkg -i diskus_0.4.0_amd64.deb
 
 Download from the AUR: [diskus](https://aur.archlinux.org/packages/diskus/) or [diskus-bin](https://aur.archlinux.org/packages/diskus-bin/)
 
-### On other distrubutions
+### On Void-based systems
+
+``` bash
+xbps-install diskus
+```
+
+### On Haiku
+
+``` bash
+pkgman install diskus
+```
+
+### On other systems
 
 Check out the [release page](https://github.com/sharkdp/diskus/releases) for binary builds.
 


### PR DESCRIPTION
Void's package "template" can be found [here](
https://github.com/void-linux/void-packages/blob/master/srcpkgs/diskus/template), and Haiku's "recipe" [here](
https://github.com/haikuports/haikuports/tree/master/sys-apps/diskus). I've also changed distributions to systems since Haiku and Darwin are not Linux, and you use systems everywhere else, anyway. Also, off-topic, but is there any reason why you haven't changed the `du -sh` in the README to `du -sb`?