### PR TITLE
remove unnecessary lib metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,3 @@ features = ["suggestions", "color", "wrap_help"]
 [profile.release]
 lto = true
 codegen-units = 1
-
-[lib]
-name = "diskus"
-path = "src/lib.rs"


### PR DESCRIPTION
These are the defaults for Cargo so they should be removed to simply they config