### PR TITLE
Add (single) verbosity flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,11 +15,6 @@ use humansize::{file_size_opts, FileSize};
 use walk::Walk;
 
 fn print_result(size: u64, errors: &[walk::Err], verbose: bool) {
-    println!(
-        "{} ({} bytes)",
-        size.file_size(file_size_opts::DECIMAL).unwrap(),
-        size
-    );
     if verbose {
         for err in errors {
             match err {
@@ -39,9 +34,14 @@ fn print_result(size: u64, errors: &[walk::Err], verbose: bool) {
         }
     } else if !errors.is_empty() {
         eprintln!(
-            "Warning: the results may be tainted. Re-run with -v/--verbose to print all errors."
+            "[diskus warning] the results may be tainted. Re-run with -v/--verbose to print all errors."
         );
     }
+    println!(
+        "{} ({} bytes)",
+        size.file_size(file_size_opts::DECIMAL).unwrap(),
+        size
+    );
 }
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,13 +15,6 @@ use humansize::{file_size_opts, FileSize};
 use walk::Walk;
 
 fn print_result(size: u64, errors: &[walk::Err], verbose: bool) {
-    let tainted = errors.iter().any(|x| {
-        if let walk::Err::NoMetadataForPath(_) = x {
-            true
-        } else {
-            false
-        }
-    });
     println!(
         "{} ({} bytes)",
         size.file_size(file_size_opts::DECIMAL).unwrap(),
@@ -44,8 +37,10 @@ fn print_result(size: u64, errors: &[walk::Err], verbose: bool) {
                 }
             }
         }
-    } else if tainted {
-        println!("Warning, results may be tainted. Try running with --verbose.");
+    } else if !errors.is_empty() {
+        eprintln!(
+            "Warning: the results may be tainted. Re-run with -v/--verbose to print all errors."
+        );
     }
 }
 


### PR DESCRIPTION
Add verbose flag and hide error messages behind it. Add additional output warning, if there were I/O errors while walking the tree.

Closes #29