### PR TITLE
Document --directories in the man page

### DIFF
--- a/doc/diskus.1
+++ b/doc/diskus.1
@@ -17,6 +17,12 @@ Output format for file sizes (decimal: MB, binary: MiB) [default: decimal]
 \fB\-v\fR, \fB\-\-verbose\fR
 Do not hide filesystem errors
 .TP
+\fB\-\-directories\fR <mode>
+Whether to count directory sizes
+(auto: included for disk usage, excluded for apparent size)
+[default: auto]
+[possible values: auto, included, excluded]
+.TP
 \fB\-b\fR, \fB\-\-apparent\-size\fR
 Compute apparent size instead of disk usage
 .TP


### PR DESCRIPTION
This just copies the documentation for `--directories` from the `--help` output to the `diskus.1` man page.