### PR TITLE
Replace atty dependency with std::io::IsTerminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,17 +59,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,7 +142,6 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 name = "diskus"
 version = "0.9.0"
 dependencies = [
- "atty",
  "clap",
  "crossbeam-channel",
  "humansize",
@@ -194,15 +182,6 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -348,28 +327,6 @@ checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ cli = [
     "dep:clap",
     "dep:humansize",
     "dep:num-format",
-    "dep:atty",
 ]
 
 [dependencies]
@@ -28,7 +27,6 @@ crossbeam-channel = "0.5"
 # CLI dependencies (optional)
 humansize = { version = "2.1", optional = true }
 num-format = { version = "0.4", optional = true }
-atty = { version = "0.2", optional = true }
 clap = { version = "4.5", features = [
     "suggestions",
     "color",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use std::io::{stdout, IsTerminal};
 use std::path::PathBuf;
 
 use clap::{builder::PossibleValuesParser, Arg, ArgAction, Command};
@@ -31,7 +32,7 @@ fn print_result(result: &DiskUsageResult, size_format: FormatSizeOptions, verbos
     }
 
     let size = result.ignore_errors().size_in_bytes();
-    if atty::is(atty::Stream::Stdout) {
+    if stdout().is_terminal() {
         println!(
             "{} ({:} bytes)",
             format_size(size, size_format),


### PR DESCRIPTION
Available since Rust 1.70: https://doc.rust-lang.org/std/io/trait.IsTerminal.html#tymethod.is_terminal

This change is useful because:

- it removes a now-unnecessary dependency
- the `atty` crate is unmaintained, https://rustsec.org/advisories/RUSTSEC-2024-0375.html
- the `atty` crate is potentially unsound on Windows, https://rustsec.org/advisories/RUSTSEC-2021-0145.html