### PR TITLE
docs: fix README grammar in benchmark section

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ interest since all programs would finish in a reasonable time that would not int
 
 In addition to `du` and `diskus`, we also add [tin-summer](https://github.com/vmchale/tin-summer) (`sn`) and
 [`dust`](https://github.com/bootandy/dust) in our comparison. Both are also written in Rust and provide
-much more features than `diskus` (check them out!). The optimal number of threads for `sn` (`-j` option) was
+many more features than `diskus` (check them out!). The optimal number of threads for `sn` (`-j` option) was
 determined via `hyperfine --parameter-scan`.
 
 ### Cold disk cache


### PR DESCRIPTION
## Summary
- fix the README grammar in the benchmark comparison section.

## Related issue
- N/A; trivial docs/comment fix.

## Guideline alignment
- No CONTRIBUTING or PR template was present; kept this to a one-file README wording fix with no behavior change.

## Validation
- Not run; docs/comment-only change.
